### PR TITLE
Improve readability of RAM addresses when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.2.1
 before_script:
-  - curl -O http://nand2tetris.org/software/nand2tetris.zip
+  - curl -L -o nand2tetris.zip 'https://drive.google.com/uc?export=download&id=1KcFPj8KQ_QAHheFmLCqs5iqC_0NCndvs'
   - unzip nand2tetris.zip
   - export EMULATOR=$TRAVIS_BUILD_DIR/nand2tetris/tools/CPUEmulator.sh
 script: bundle exec rspec --format documentation

--- a/spec/acceptance/translator_spec.rb
+++ b/spec/acceptance/translator_spec.rb
@@ -2,9 +2,11 @@ require 'open3'
 require 'tmpdir'
 require 'support/example_from_directory'
 require 'support/helpers/emulation_helper'
+require 'support/helpers/readability_helper'
 
 RSpec.describe 'the translator' do
   include EmulationHelper
+  include ReadabilityHelper
 
   TRANSLATOR_PATH = File.expand_path('../../../bin/translator', __FILE__)
   EXAMPLES_PATH = File.expand_path('../examples', __FILE__)
@@ -24,7 +26,11 @@ RSpec.describe 'the translator' do
 
         unless status.success?
           STDERR.write error
-          expect(File.read(example.actual_pathname)).to eq File.read(example.expected_pathname)
+
+          actual_output = File.read(example.actual_pathname)
+          expected_output = File.read(example.expected_pathname)
+
+          expect(parse_table(actual_output)).to eq(parse_table(expected_output))
         end
       end
     end

--- a/spec/support/helpers/readability_helper.rb
+++ b/spec/support/helpers/readability_helper.rb
@@ -1,0 +1,30 @@
+require 'support/ram_description'
+
+module ReadabilityHelper
+  ADDRESS_NAMES = %i[SP LCL ARG THIS THAT]
+
+  def parse_table(table)
+    header, *body = table.split("\n")
+
+    ram_addresses = parse_header(header)
+
+    body.map do |row|
+      ram_addresses.zip(parse_row(row)).to_h
+    end
+  end
+
+  def parse_header(header)
+    parse_row(header).map { |h| readable_name(h) }
+  end
+
+  def parse_row(row)
+    row.split("|")[1..-1].map(&:strip)
+  end
+
+  def readable_name(address)
+    index = Integer(address.gsub(/[^\d]/, ""))
+
+    name = ADDRESS_NAMES[index]
+    name ? "#{address} (#{name})" : address
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/computationclub/vm-translator/issues/1

This makes it so the test output is easier to read when acceptance tests
fail. Instead of comparing `examples/**/*.tst` files against the
emulator’s output, we first parse these files into Ruby arrays so
RSpec’s error output is is more specific.

We also include a ‘friendly’ name for RAM addresses in the range 0 to 5.
These have special meaning which could be useful context.

Output before:
```
Diff:
|RAM[256]| RAM[3] | RAM[4] |RAM[3032]|RAM[3046]|
|   6084 |   3031 |   3040 |     32  |     46  |
|   6084 |   3030 |   3040 |     32  |     46  |
```

Output after:
```diff
Diff:
[{"RAM[256]"=>"6084",
-  "RAM[3] (THIS)"=>"3031",
+  "RAM[3] (THIS)"=>"3030",
   "RAM[4] (THAT)"=>"3040",
   "RAM[3032]"=>"32",
   "RAM[3046]"=>"46"}]
```