### PR TITLE
Switch from Travis CI (RIP) to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+          bundler-cache: true
+      - run: |
+          curl --location --output nand2tetris.zip 'https://drive.google.com/uc?id=1xZzcMIUETv3u3sdpM_oTJSTetpVee3KZ&export=download'
+          unzip nand2tetris.zip
+        if: steps.cache-nand2tetris.outputs.cache-hit != 'true'
+      - run: bundle exec rspec
+        env:
+          EMULATOR: nand2tetris/tools/CPUEmulator.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           java-version: 11
           distribution: adopt
+      - uses: actions/cache@v2
+        id: cache-nand2tetris
+        with:
+          path: nand2tetris
+          key: nand2tetris
       - run: |
           curl --location --output nand2tetris.zip 'https://drive.google.com/uc?id=1xZzcMIUETv3u3sdpM_oTJSTetpVee3KZ&export=download'
           unzip nand2tetris.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
         with:
           ruby-version: 3.0
           bundler-cache: true
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: adopt
       - run: |
           curl --location --output nand2tetris.zip 'https://drive.google.com/uc?id=1xZzcMIUETv3u3sdpM_oTJSTetpVee3KZ&export=download'
           unzip nand2tetris.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.1
-before_script:
-  - curl -L -o nand2tetris.zip 'https://drive.google.com/uc?export=download&id=1KcFPj8KQ_QAHheFmLCqs5iqC_0NCndvs'
-  - unzip nand2tetris.zip
-  - export EMULATOR=$TRAVIS_BUILD_DIR/nand2tetris/tools/CPUEmulator.sh
-script: bundle exec rspec --format documentation


### PR DESCRIPTION
I haven’t followed the Travis CI story but I know that our tests don’t run there any more. It’s easy enough to switch to GitHub Actions so I’ve done that.