### PR TITLE
Refactor CodeWriter#write_arithmetic

### DIFF
--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -27,7 +27,7 @@ class CodeWriter
         output.puts <<-EOF
           @SP
           // SP--
-          AMD=M-1
+          AM=M-1
           // Load M[SP]
           D=M
           // Load M[SP-1]
@@ -46,7 +46,7 @@ class CodeWriter
         output.puts <<-EOF
           @SP
           // SP--
-          AMD=M-1
+          AM=M-1
           // Load M[SP]
           D=M
           // Load M[SP-1]

--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -27,9 +27,8 @@ class CodeWriter
         output.puts <<-EOF
           @SP
           // SP--
-          MD=M-1
+          AMD=M-1
           // Load M[SP]
-          A=M
           D=M
           // Load M[SP-1]
           A=A-1
@@ -47,9 +46,8 @@ class CodeWriter
         output.puts <<-EOF
           @SP
           // SP--
-          MD=M-1
+          AMD=M-1
           // Load M[SP]
-          A=M
           D=M
           // Load M[SP-1]
           A=A-1

--- a/lib/code_writer.rb
+++ b/lib/code_writer.rb
@@ -24,12 +24,8 @@ class CodeWriter
     cache_implementation(command) do
       case command
       when 'add', 'sub', 'and', 'or'
+        output.pop_register_d
         output.puts <<-EOF
-          @SP
-          // SP--
-          AM=M-1
-          // Load M[SP]
-          D=M
           // Load M[SP-1]
           A=A-1
           // Add M[SP] to M[SP-1]
@@ -43,12 +39,8 @@ class CodeWriter
         EOF
       when 'eq', 'gt', 'lt'
         true_label, end_label = 2.times.map { generate_label }
+        output.pop_register_d
         output.puts <<-EOF
-          @SP
-          // SP--
-          AM=M-1
-          // Load M[SP]
-          D=M
           // Load M[SP-1]
           A=A-1
           // Subtract M[SP-1] from M[SP]


### PR DESCRIPTION
We were emitting more instructions than necessary here, plus missing the opportunity to rely on a helper method which would’ve emitted the correct instructions in the first place.